### PR TITLE
Fix test timeouts in CI by increasing timeout and reducing wait times

### DIFF
--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -217,7 +217,7 @@ describe('end-to-end workflow', () => {
     // Wait for new session detection (with automatic retry in CI environments)
     await waitForWithRetry(
       () => newSessionDetected,
-      TIMEOUTS.newSessionLong,
+      TIMEOUTS.newSession,
       undefined,
       'new session detection'
     );

--- a/test/helpers/timeouts.ts
+++ b/test/helpers/timeouts.ts
@@ -19,7 +19,6 @@ export const TIMEOUTS = {
   // File watching timeouts
   fileChange: 3000 * CI_MULTIPLIER,        // 3s in dev, 9s in CI
   newSession: 5000 * CI_MULTIPLIER,        // 5s in dev, 15s in CI
-  newSessionLong: 20000 * CI_MULTIPLIER,   // 20s in dev, 60s in CI
 
   // General operation timeouts
   shortOperation: 1000 * CI_MULTIPLIER,    // 1s in dev, 3s in CI

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
+// Detect CI environment
+const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    testTimeout: 30000, // E2E tests need more time
+    testTimeout: isCI ? 90000 : 30000, // 90s in CI to allow for retry logic, 30s locally
     hookTimeout: 20000,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Tests using waitForWithRetry were timing out in CI because the retry logic could take up to 60s per attempt (3 retries = 180s), exceeding the 30s test timeout. This was causing the "should handle new session creation" test to fail.

Changes:
- Increase vitest testTimeout to 90s in CI (30s locally) to accommodate retry logic
- Replace TIMEOUTS.newSessionLong (60s in CI) with newSession (15s in CI)
- Remove unused newSessionLong constant

Now all tests fit within 90s timeout with 43s buffer for overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)