### PR TITLE
Filter out conversations with only sidechain messages

### DIFF
--- a/src/lib/file-system.ts
+++ b/src/lib/file-system.ts
@@ -449,6 +449,17 @@ export async function listConversations(projectPath: string): Promise<Conversati
         // Use cross-file summary if this conversation doesn't have one
         const finalSummary = branch.summary || globalSummaryMap.get(branch.leafUuid) || null;
 
+        // Skip conversations with no real user interaction:
+        // - No summary AND no non-sidechain user messages (fallbackName is null)
+        // These are typically warmup sessions, canceled sessions, or internal operations
+        if (!finalSummary && !branch.fallbackName) {
+          logger.debug('[listConversations] Skipping conversation with no user interaction', {
+            sessionId: result.sessionId,
+            leafUuid: branch.leafUuid,
+          });
+          continue;
+        }
+
         allConversations.push({
           id: `${result.sessionId}-${branch.leafUuid}`,
           name: finalSummary || branch.fallbackName || 'Unnamed conversation',


### PR DESCRIPTION
Conversations that have no real user interaction (only sidechain messages or no user messages) are now filtered from the conversation list. These are typically warmup sessions, canceled sessions, or internal operations that show up as "Unnamed conversation" and aren't meaningful to display.

This matches Claude Code's /resume behavior which also filters these out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)