### PR TITLE
Filter out sidechain-only conversations and prevent cross-file summar…

### DIFF
--- a/src/lib/file-system.ts
+++ b/src/lib/file-system.ts
@@ -446,8 +446,45 @@ export async function listConversations(projectPath: string): Promise<Conversati
 
     for (const result of fileResults) {
       for (const branch of result.conversations) {
-        // Use cross-file summary if this conversation doesn't have one
-        const finalSummary = branch.summary || globalSummaryMap.get(branch.leafUuid) || null;
+        // Skip conversations with no real user interaction FIRST:
+        // - No non-sidechain user messages (fallbackName is null)
+        // These are typically warmup sessions, canceled sessions, or internal operations
+        // We check this BEFORE applying cross-file summaries because those summaries
+        // are meant for the original conversation, not for sidechain-only warmup messages
+        if (!branch.fallbackName) {
+          // Only use local summary if it exists, not cross-file summaries
+          const localSummary = branch.summary;
+
+          // Skip if no local summary either
+          if (!localSummary) {
+            logger.debug('[listConversations] Skipping conversation with no user interaction', {
+              sessionId: result.sessionId,
+              leafUuid: branch.leafUuid,
+            });
+            continue;
+          }
+
+          // Has local summary but no user messages - unusual but keep it
+          allConversations.push({
+            id: `${result.sessionId}-${branch.leafUuid}`,
+            name: localSummary,
+            sessionPath: result.filePath,
+            sessionId: result.sessionId,
+            leafUuid: branch.leafUuid,
+            mtime: new Date(branch.timestamp),
+          });
+          continue;
+        }
+
+        // Has real user messages - use cross-file summary if available
+        let finalSummary = branch.summary || globalSummaryMap.get(branch.leafUuid) || null;
+
+        // Filter out API error messages masquerading as summaries
+        // These are error messages from resumed sessions, not real conversation names
+        // Pattern: "API Error: 400 {"type":"error",...}"
+        if (finalSummary && /^API Error: \d+ \{"type":"error"/.test(finalSummary)) {
+          finalSummary = null;
+        }
 
         allConversations.push({
           id: `${result.sessionId}-${branch.leafUuid}`,


### PR DESCRIPTION
…y misattribution

Fixes two issues with conversation filtering:

1. **Sidechain message filtering**: Added isSidechain checks to all message extraction functions (extractUserMessage, findRootUserMessage, extractThinkingBlocks, extractSessionInfo) to prevent sidechain messages (warmup, internal ops) from being treated as real user messages.

2. **Cross-file summary misattribution**: Changed listConversations to check for real user messages BEFORE applying cross-file summaries. This prevents sidechain-only conversations from inheriting summaries meant for different conversations in other sessions.

Results:
- Filters out "Warmup" and other sidechain-only sessions
- Prevents generic summaries like "Claude Code CLI Ready for Development Tasks" from appearing on unrelated conversations
- Reduces conversation list from 186 to 162 (24 sidechain-only filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)