### PR TITLE
Fix file watcher race condition by adding settling delay to waitForReady

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Detect if running in CI environment
+ */
+const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+
+/**
+ * CI multiplier for timing-sensitive operations
+ * File operations are slower in CI, so we need more conservative timeouts
+ */
+const CI_MULTIPLIER = isCI ? 2 : 1;
+
+/**
  * Maximum number of message blocks to load initially
  *
  * Controls how many messages are loaded from disk on startup.
@@ -122,18 +133,28 @@ export const SESSION_ID_DISPLAY_LENGTH = 8;
  * How long a file must be stable before triggering a change event.
  * Prevents multiple events during rapid file writes.
  *
- * Default: 200ms
+ * Default: 200ms (400ms in CI)
  */
-export const WATCHER_STABILITY_THRESHOLD = 200;
+export const WATCHER_STABILITY_THRESHOLD = 200 * CI_MULTIPLIER;
 
 /**
  * File watcher poll interval in milliseconds
  *
  * How often to check for file changes when using polling.
  *
- * Default: 50ms
+ * Default: 50ms (100ms in CI)
  */
-export const WATCHER_POLL_INTERVAL = 50;
+export const WATCHER_POLL_INTERVAL = 50 * CI_MULTIPLIER;
+
+/**
+ * Watcher settling delay in milliseconds
+ *
+ * Time to wait after chokidar 'ready' event before considering watcher fully active.
+ * Prevents race conditions where files are created before watcher is fully watching.
+ *
+ * Default: 100ms (200ms in CI)
+ */
+export const WATCHER_READY_SETTLING_DELAY = 100 * CI_MULTIPLIER;
 
 /**
  * Queue concurrency for file operations

--- a/src/lib/session-watcher.ts
+++ b/src/lib/session-watcher.ts
@@ -6,6 +6,7 @@ import {
   FILE_OPERATION_QUEUE_CONCURRENCY,
   WATCHER_STABILITY_THRESHOLD,
   WATCHER_POLL_INTERVAL,
+  WATCHER_READY_SETTLING_DELAY,
   BYTES_TO_MB,
 } from './constants.js';
 
@@ -178,9 +179,14 @@ export class SessionWatcher {
   /**
    * Wait for the watcher to be ready
    * Must be called before the watcher will detect file changes
+   *
+   * Includes a settling delay after the 'ready' event to ensure chokidar
+   * is fully watching before files are created, preventing race conditions
    */
   async waitForReady(): Promise<void> {
     await this.readyPromise;
+    // Give chokidar time to fully settle after ready event
+    await new Promise(resolve => setTimeout(resolve, WATCHER_READY_SETTLING_DELAY));
   }
 
   /**

--- a/test/integration/file-watching.test.ts
+++ b/test/integration/file-watching.test.ts
@@ -348,9 +348,6 @@ describe("file-watching integration", () => {
 
     await watcher.waitForReady();
 
-    // Wait a bit for the watcher to settle after initialization
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     // Create a new session with leafUuid pointing to a non-existent parent
     // This simulates Claude Code's auto-linking behavior where new sessions
     // get a summary with leafUuid from a previous session that might not be watched


### PR DESCRIPTION
Tests were failing in CI due to a race condition where files were created before chokidar was fully watching, despite the 'ready' event having fired. The test "should distinguish between new sessions and files with leafUuid" consistently timed out after 47s (3 retries), never detecting the new file.

Root cause: Chokidar's 'ready' event fires after initial scan completes, but there's a small window before it's fully watching for new files.

Solution: Add a settling delay to waitForReady() itself, so ALL tests (current and future) get the fix automatically. No more per-test workarounds.

Changes:
- Add CI detection and multiplier to constants.ts
- Create WATCHER_READY_SETTLING_DELAY constant (100ms local, 200ms CI)
- Update SessionWatcher.waitForReady() to include settling delay
- Remove manual workaround from existing test (now handled automatically)
- Make WATCHER_STABILITY_THRESHOLD and WATCHER_POLL_INTERVAL CI-aware

This prevents whack-a-mole by fixing the root cause in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)