### PR TITLE
Align session metadata with subject lines

### DIFF
--- a/src/components/SessionSelector.tsx
+++ b/src/components/SessionSelector.tsx
@@ -39,7 +39,7 @@ const SessionItem: React.FC<SessionItemProps> = ({ isSelected = false, label }) 
     <Box flexDirection="column" marginBottom={1}>
       <Text>{isSelected ? `> ${name}` : `  ${name}`}</Text>
       <Text dimColor>
-        {' '}
+        {'  '}
         {gitBranch ? `${timeAgo} · ${gitBranch}` : timeAgo}
       </Text>
     </Box>


### PR DESCRIPTION
The footer text (timestamp and branch) was indented by 1 space while subject lines use 2 characters (either "> " or "  "), causing misalignment. Updated footer padding to match subject indentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)