### PR TITLE
Fix: Assign colors to sessions detected at runtime

### DIFF
--- a/src/components/StreamView.tsx
+++ b/src/components/StreamView.tsx
@@ -4,7 +4,7 @@
  * for maximum performance with thousands of messages
  */
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useRef } from 'react';
 import { Box } from 'ink';
 import { assignSessionColors, getProjectColor } from '../lib/colors.js';
 import { renderFooterToString } from '../lib/footer-renderer.js';
@@ -38,20 +38,49 @@ export const StreamView: React.FC<StreamViewProps> = ({ sessionFiles, onBack }) 
     sessionFiles.every((s) => s.projectName === firstProject.projectName);
   const projectName = firstProject?.projectName;
 
+  // Store project color for color assignment
+  const projectColor = useMemo(
+    () => (projectName ? getProjectColor(projectName) : undefined),
+    [projectName],
+  );
+
   // Create unique session color mapping, excluding the project's color
-  const sessionColorMap = useMemo(() => {
+  // Use ref so we can mutate it when new sessions are detected
+  const sessionColorMapRef = useRef<Map<string, ChalkInstance>>(new Map());
+
+  // Initialize/update the color map when sessionFiles changes
+  useMemo(() => {
     const sessionPaths = sessionFiles.map((s) => s.sessionPath);
-    const projectColor = projectName ? getProjectColor(projectName) : undefined;
-    return assignSessionColors(sessionPaths, projectColor);
-  }, [sessionFiles, projectName]);
+    const initialColorMap = assignSessionColors(sessionPaths, projectColor);
+    sessionColorMapRef.current = initialColorMap;
+  }, [sessionFiles, projectColor]);
 
   // Helper to get color for a message block
+  // Dynamically assigns colors to unknown sessions
   const getSessionColor = useCallback(
     (block: DisplayMessageBlock): ChalkInstance | undefined => {
-      // Use sessionPath for consistent color lookup (session names can change dynamically)
-      return block.sessionPath ? sessionColorMap.get(block.sessionPath) : undefined;
+      if (!block.sessionPath) return undefined;
+
+      // Check if we already have a color for this session
+      let color = sessionColorMapRef.current.get(block.sessionPath);
+
+      // If not, assign a new color dynamically
+      if (!color) {
+        // Get all currently assigned session paths
+        const existingPaths = Array.from(sessionColorMapRef.current.keys());
+        // Create a temporary array with the new path appended
+        const allPaths = [...existingPaths, block.sessionPath];
+        // Reassign colors to include the new session
+        const updatedColorMap = assignSessionColors(allPaths, projectColor);
+        // Update our ref with the new color map
+        sessionColorMapRef.current = updatedColorMap;
+        // Get the color for the new session
+        color = updatedColorMap.get(block.sessionPath);
+      }
+
+      return color;
     },
-    [sessionColorMap],
+    [projectColor],
   );
 
   // Get Claude settings


### PR DESCRIPTION
New sessions discovered after initialization were appearing white because they weren't in the initial sessionColorMap. Now dynamically assigns colors to unknown sessions on-demand, ensuring all sessions get colored consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)