### PR TITLE
Refactor: Remove dead code and unused helpers

### DIFF
--- a/src/lib/footer-renderer.ts
+++ b/src/lib/footer-renderer.ts
@@ -46,10 +46,6 @@ export function renderFooterToString(options: FooterOptions): string {
   const lines: string[] = [];
   const leftPadding = ' '.repeat(CURSOR_WIDTH);
 
-  // Debug: log terminal width being used
-  // Uncomment to debug resize issues:
-  // console.error(`[FooterRenderer] Rendering with terminalWidth=${terminalWidth}`);
-
   // Skip footer if not showing single session or all sessions for a project
   if (!isSingleSession && !isWatchingAllForProject) {
     if (showBack) {

--- a/src/services/message-store.ts
+++ b/src/services/message-store.ts
@@ -1,4 +1,4 @@
-import type { MessageBlock, ThinkingBlock, UserMessage } from '../lib/parser.js';
+import type { ThinkingBlock, UserMessage } from '../lib/parser.js';
 import { logger } from '../lib/logger.js';
 import { getBlockKey } from '../lib/message-utils.js';
 
@@ -152,13 +152,5 @@ export class MessageStore {
    */
   getBlockCount(): number {
     return this.blocks.length;
-  }
-
-  /**
-   * Check if a block exists by key
-   */
-  hasBlock(block: MessageBlock): boolean {
-    const key = getBlockKey(block);
-    return this.blockKeys.has(key);
   }
 }

--- a/test/helpers/file-watching.ts
+++ b/test/helpers/file-watching.ts
@@ -2,38 +2,6 @@ import fs from "fs/promises";
 import { TIMEOUTS, logTimeoutDebug } from "./timeouts.js";
 
 /**
- * Wait for a file to be modified
- * Useful for testing file watching functionality
- */
-export async function waitForFileChange(
-  filePath: string,
-  timeoutMs: number = TIMEOUTS.fileChange
-): Promise<void> {
-  const startTime = Date.now();
-  const initialStat = await fs.stat(filePath);
-  const initialMtime = initialStat.mtime.getTime();
-
-  return new Promise((resolve, reject) => {
-    const interval = setInterval(async () => {
-      try {
-        const stat = await fs.stat(filePath);
-        if (stat.mtime.getTime() > initialMtime) {
-          clearInterval(interval);
-          resolve();
-        } else if (Date.now() - startTime > timeoutMs) {
-          clearInterval(interval);
-          logTimeoutDebug(`waitForFileChange(${filePath})`, Date.now() - startTime, timeoutMs);
-          reject(new Error(`File did not change within ${timeoutMs}ms`));
-        }
-      } catch (error) {
-        clearInterval(interval);
-        reject(error);
-      }
-    }, 100);
-  });
-}
-
-/**
  * Append content to a file (simulating new messages being added)
  */
 export async function appendToFile(

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -45,18 +45,3 @@ export async function readFixture(fixtureName: string): Promise<string> {
   const sourcePath = path.join(FIXTURES_DIR, fixtureName);
   return fs.readFile(sourcePath, "utf-8");
 }
-
-/**
- * Copy multiple fixtures to a project directory
- */
-export async function copyFixturesToProject(
-  projectPath: string,
-  fixtures: Array<{ name: string; sessionId: string }>
-): Promise<void> {
-  await Promise.all(
-    fixtures.map(({ name, sessionId }) => {
-      const destPath = path.join(projectPath, `${sessionId}.jsonl`);
-      return copyFixture(name, destPath);
-    })
-  );
-}

--- a/test/unit/message-store.test.ts
+++ b/test/unit/message-store.test.ts
@@ -170,22 +170,6 @@ describe("MessageStore", () => {
     });
   });
 
-  describe("hasBlock", () => {
-    it("should return false for block not in store", () => {
-      const block = createUserMessage("msg-1", "2025-01-15T10:00:00.000Z");
-
-      expect(store.hasBlock(block)).toBe(false);
-    });
-
-    it("should return true for block in store", () => {
-      const block = createUserMessage("msg-1", "2025-01-15T10:00:00.000Z");
-
-      store.addBlocks([block]);
-
-      expect(store.hasBlock(block)).toBe(true);
-    });
-  });
-
   describe("clear", () => {
     it("should remove all blocks", () => {
       const blocks = [


### PR DESCRIPTION
Removed unused methods, imports, and test helpers to reduce code clutter:
- MessageStore.hasBlock() method and MessageBlock import (only used in tests)
- Commented debug console.error in footer-renderer
- Test helpers: waitForFileChange() and copyFixturesToProject()
- Tests for removed hasBlock() method

All typechecks and lints pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)